### PR TITLE
Fix ANDROID_NDK_HOME envar

### DIFF
--- a/27.0/Dockerfile
+++ b/27.0/Dockerfile
@@ -57,7 +57,7 @@ RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "tools" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platform-tools" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "build-tools;30.0.3"
 
-RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-S"
+RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-31"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-30"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-29"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-28"
@@ -68,7 +68,6 @@ RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-24"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-23"
 
 # ndk stuff
-ENV ANDROID_NDK_HOME "/opt/android/sdk/ndk/${ndk_version}"
 ENV ANDROID_NDK_ROOT ANDROID_NDK_HOME
 ENV PATH "${ANDROID_NDK_HOME}:${PATH}"
 # stable
@@ -79,6 +78,7 @@ RUN ndk_version="22.1.7171670" && \
 RUN ndk_version="21.4.7075529" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "ndk;${ndk_version}" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "cmake;3.6.4111459"
+ENV ANDROID_NDK_HOME "/home/circleci/android-sdk/ndk/22.1.7171670"
 
 # install extras
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "extras;android;m2repository" && \

--- a/28.0/Dockerfile
+++ b/28.0/Dockerfile
@@ -57,7 +57,7 @@ RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "tools" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platform-tools" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "build-tools;30.0.3"
 
-RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-S"
+RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-31"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-30"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-29"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-28"
@@ -68,7 +68,6 @@ RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-24"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-23"
 
 # ndk stuff
-ENV ANDROID_NDK_HOME "/opt/android/sdk/ndk/${ndk_version}"
 ENV ANDROID_NDK_ROOT ANDROID_NDK_HOME
 ENV PATH "${ANDROID_NDK_HOME}:${PATH}"
 # stable
@@ -79,6 +78,7 @@ RUN ndk_version="22.1.7171670" && \
 RUN ndk_version="21.4.7075529" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "ndk;${ndk_version}" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "cmake;3.6.4111459"
+ENV ANDROID_NDK_HOME "/home/circleci/android-sdk/ndk/22.1.7171670"
 
 # install extras
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "extras;android;m2repository" && \

--- a/29.0/Dockerfile
+++ b/29.0/Dockerfile
@@ -57,7 +57,7 @@ RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "tools" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platform-tools" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "build-tools;30.0.3"
 
-RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-S"
+RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-31"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-30"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-29"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-28"
@@ -68,7 +68,6 @@ RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-24"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-23"
 
 # ndk stuff
-ENV ANDROID_NDK_HOME "/opt/android/sdk/ndk/${ndk_version}"
 ENV ANDROID_NDK_ROOT ANDROID_NDK_HOME
 ENV PATH "${ANDROID_NDK_HOME}:${PATH}"
 # stable
@@ -79,6 +78,7 @@ RUN ndk_version="22.1.7171670" && \
 RUN ndk_version="21.4.7075529" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "ndk;${ndk_version}" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "cmake;3.6.4111459"
+ENV ANDROID_NDK_HOME "/home/circleci/android-sdk/ndk/22.1.7171670"
 
 # install extras
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "extras;android;m2repository" && \

--- a/30.0/Dockerfile
+++ b/30.0/Dockerfile
@@ -57,7 +57,7 @@ RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "tools" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platform-tools" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "build-tools;30.0.3"
 
-RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-S"
+RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-31"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-30"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-29"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-28"
@@ -68,7 +68,6 @@ RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-24"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-23"
 
 # ndk stuff
-ENV ANDROID_NDK_HOME "/opt/android/sdk/ndk/${ndk_version}"
 ENV ANDROID_NDK_ROOT ANDROID_NDK_HOME
 ENV PATH "${ANDROID_NDK_HOME}:${PATH}"
 # stable
@@ -79,6 +78,7 @@ RUN ndk_version="22.1.7171670" && \
 RUN ndk_version="21.4.7075529" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "ndk;${ndk_version}" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "cmake;3.6.4111459"
+ENV ANDROID_NDK_HOME "/home/circleci/android-sdk/ndk/22.1.7171670"
 
 # install extras
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "extras;android;m2repository" && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -57,7 +57,7 @@ RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "tools" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platform-tools" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "build-tools;30.0.3"
 
-RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-S"
+RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-31"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-30"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-29"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-28"
@@ -68,7 +68,6 @@ RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-24"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-23"
 
 # ndk stuff
-ENV ANDROID_NDK_HOME "/opt/android/sdk/ndk/${ndk_version}"
 ENV ANDROID_NDK_ROOT ANDROID_NDK_HOME
 ENV PATH "${ANDROID_NDK_HOME}:${PATH}"
 # stable
@@ -79,6 +78,7 @@ RUN ndk_version="22.1.7171670" && \
 RUN ndk_version="21.4.7075529" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "ndk;${ndk_version}" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "cmake;3.6.4111459"
+ENV ANDROID_NDK_HOME "/home/circleci/android-sdk/ndk/22.1.7171670"
 
 # install extras
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "extras;android;m2repository" && \

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-docker build --file 30.0/Dockerfile -t cimg/android:30.0 .
-docker build --file 29.0/Dockerfile -t cimg/android:29.0 .
-docker build --file 28.0/Dockerfile -t cimg/android:28.0 .
 docker build --file 27.0/Dockerfile -t cimg/android:27.0 .
+docker build --file 28.0/Dockerfile -t cimg/android:28.0 .
+docker build --file 29.0/Dockerfile -t cimg/android:29.0 .
+docker build --file 30.0/Dockerfile -t cimg/android:30.0 .


### PR DESCRIPTION
This variable was set incorrectly. It will need to further be updated soon to point to the latest NDK specifically.

Since the last update to this image, Android 12 has moved from preview to stable. Thus `android-S` has changed to `android-31`.