### PR TITLE
Fix gradle is not found due to wrong PATH

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -22,8 +22,8 @@ RUN curl -sSL -o /tmp/maven.tar.gz http://apache.osuosl.org/maven/maven-3/${MAVE
     rm -rf /tmp/maven.tar.gz && \
 	mkdir -p /home/circleci/.m2
 
-ENV PATH $PATH:/usr/local/gradle-${GRADLE_VERSION}/bin
 ENV GRADLE_VERSION "7.1.1"
+ENV PATH $PATH:/usr/local/gradle-${GRADLE_VERSION}/bin
 RUN URL=https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip && \
     curl -sSL -o /tmp/gradle.zip $URL && \
     sudo unzip -d /usr/local /tmp/gradle.zip && \


### PR DESCRIPTION
This change adds Gradle binaries to PATH right after GRADLE_VERSION becomes available.