### PR TITLE
Add missing variants, tag v2021.09.2

### DIFF
--- a/2021.09/Dockerfile
+++ b/2021.09/Dockerfile
@@ -35,7 +35,7 @@ ENV ANDROID_SDK_ROOT $ANDROID_HOME
 ENV CMDLINE_TOOLS_ROOT "${ANDROID_HOME}/cmdline-tools/latest/bin"
 ENV ADB_INSTALL_TIMEOUT 120
 ENV PATH "${ANDROID_HOME}/emulator:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/platform-tools/bin:${PATH}"
-RUN SDK_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-7302050_latest.zip" && \
+RUN SDK_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip" && \
 	mkdir -p ${ANDROID_HOME}/cmdline-tools && \
 	mkdir ${ANDROID_HOME}/platforms && \
 	mkdir ${ANDROID_HOME}/ndk && \

--- a/2021.09/browsers/Dockerfile
+++ b/2021.09/browsers/Dockerfile
@@ -1,0 +1,63 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/android:2021.09.2-node
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+
+    # Install Java only if it's not already available
+    # Java is installed for Selenium
+    if ! command -v java > /dev/null; then \
+        echo "Java not found in parent image, installing..." && \
+        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+    fi && \
+
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+
+    # Google Chrome deps
+	# Some of these packages should be pulled into their own section
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+		libxss1 \
+        xdg-utils \
+		xvfb \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Below is setup to allow xvfb to start when the container starts up.
+# The label in particular allows this image to override what CircleCI does
+# when booting the image.
+LABEL com.circleci.preserve-entrypoint=true
+ENV DISPLAY=":99"
+#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
+#	chmod +x /tmp/entrypoint && \
+#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
+	sudo chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/2021.09/ndk/Dockerfile
+++ b/2021.09/ndk/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/android:2021.09.1
+FROM cimg/android:2021.09.2
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -8,7 +8,7 @@ RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "cmake;3.6.4111459" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "cmake;3.10.2.4988404"
 
 # Setup LTS release
-ENV NDK_LTS_VERSION "21.4.7075529"
+ENV NDK_LTS_VERSION "23.0.7599858"
 ENV ANDROID_NDK_HOME "/home/circleci/android-sdk/ndk/${NDK_LTS_VERSION}"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "ndk;${NDK_LTS_VERSION}"
 
@@ -16,5 +16,5 @@ ENV ANDROID_NDK_ROOT "${ANDROID_NDK_HOME}"
 ENV PATH "${ANDROID_NDK_HOME}:${PATH}"
 
 # Setup Stable release
-ENV NDK_STABLE_VERSION "21.4.7075529"
+ENV NDK_STABLE_VERSION "22.1.7171670"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "ndk;${NDK_STABLE_VERSION}"

--- a/2021.09/node/Dockerfile
+++ b/2021.09/node/Dockerfile
@@ -1,0 +1,20 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/android:2021.09.2
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Dockerfile will pull the latest LTS release from cimg-node.
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/master/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz nodeAliases.txt && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.5
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
-docker build --file 2021.09/Dockerfile -t cimg/android:2021.09.1  -t cimg/android:2021.09 .
-docker build --file 2021.09/ndk/Dockerfile -t cimg/android:2021.09.1-ndk  -t cimg/android:2021.09-ndk .
+docker build --file 2021.09/Dockerfile -t cimg/android:2021.09.2  -t cimg/android:2021.09 .
+docker build --file 2021.09/ndk/Dockerfile -t cimg/android:2021.09.2-ndk  -t cimg/android:2021.09-ndk .
+docker build --file 2021.09/node/Dockerfile -t cimg/android:2021.09.2-node  -t cimg/android:2021.09-node .
+docker build --file 2021.09/browsers/Dockerfile -t cimg/android:2021.09.2-browsers  -t cimg/android:2021.09-browsers .

--- a/manifest
+++ b/manifest
@@ -2,4 +2,4 @@
 
 repository=android
 parent=base
-variants=(ndk)
+variants=(ndk node browsers)


### PR DESCRIPTION
I found that missing variants in the manifest file: `browsers` and `node`. These variants described as available in the [README](https://github.com/CircleCI-Public/cimg-android#variants). This PR adds those two variants in the manifest file.

I also added Dockerfiles with tag 2021.09.2 via script, but I'm not sure I could do this. (perhaps only for the maintainer during release?)