### PR TITLE
Android March 2022 [release]

### DIFF
--- a/2022.03/Dockerfile
+++ b/2022.03/Dockerfile
@@ -2,7 +2,7 @@
 
 # Do not edit individual Dockerfiles manually. Instead, please make changes to the Dockerfile.template, which will be used by the build script to generate Dockerfiles.
 
-FROM %%NAMESPACE%%/%%PARENT%%:2022.01
+FROM cimg/base:2022.01
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/2022.03/browsers/Dockerfile
+++ b/2022.03/browsers/Dockerfile
@@ -1,0 +1,63 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/android:2022.03.1-node
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+
+    # Install Java only if it's not already available
+    # Java is installed for Selenium
+    if ! command -v java > /dev/null; then \
+        echo "Java not found in parent image, installing..." && \
+        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+    fi && \
+
+    # Firefox deps
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+		libdbus-glib-1-2 \
+		libgtk-3-dev \
+		libxt6 \
+	&& \
+
+    # Google Chrome deps
+	# Some of these packages should be pulled into their own section
+    sudo apt-get install -y --no-install-recommends --no-upgrade \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libgbm1 \
+        libgdk-pixbuf2.0-0 \
+        libgtk-3-0 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libxcursor1 \
+		libxss1 \
+        xdg-utils \
+		xvfb \
+	&& \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Below is setup to allow xvfb to start when the container starts up.
+# The label in particular allows this image to override what CircleCI does
+# when booting the image.
+LABEL com.circleci.preserve-entrypoint=true
+ENV DISPLAY=":99"
+#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
+#	chmod +x /tmp/entrypoint && \
+#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
+	sudo chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/2022.03/ndk/Dockerfile
+++ b/2022.03/ndk/Dockerfile
@@ -1,0 +1,21 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/android:2022.03.1
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "cmake;3.10.2.4988404" && \
+	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "cmake;3.18.1"
+
+# Use the last two versions of the NDK
+# Setup LTS release
+ENV NDK_LTS_VERSION "23.1.7779620"
+ENV ANDROID_NDK_HOME "/home/circleci/android-sdk/ndk/${NDK_LTS_VERSION}"
+RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "ndk;${NDK_LTS_VERSION}"
+
+ENV ANDROID_NDK_ROOT "${ANDROID_NDK_HOME}"
+ENV PATH "${ANDROID_NDK_HOME}:${PATH}"
+
+# Setup Stable release
+ENV NDK_STABLE_VERSION "22.1.7171670"
+RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "ndk;${NDK_STABLE_VERSION}"

--- a/2022.03/node/Dockerfile
+++ b/2022.03/node/Dockerfile
@@ -1,0 +1,20 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/android:2022.03.1
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Dockerfile will pull the latest LTS release from cimg-node.
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz nodeAliases.txt && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.5
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 2022.01/Dockerfile -t cimg/android:2022.01.1  -t cimg/android:2022.01 .
-docker build --file 2022.01/ndk/Dockerfile -t cimg/android:2022.01.1-ndk  -t cimg/android:2022.01-ndk .
-docker build --file 2022.01/node/Dockerfile -t cimg/android:2022.01.1-node  -t cimg/android:2022.01-node .
-docker build --file 2022.01/browsers/Dockerfile -t cimg/android:2022.01.1-browsers  -t cimg/android:2022.01-browsers .
+docker build --file 2022.03/Dockerfile -t cimg/android:2022.03.1  -t cimg/android:2022.03 .
+docker build --file 2022.03/ndk/Dockerfile -t cimg/android:2022.03.1-ndk  -t cimg/android:2022.03-ndk .
+docker build --file 2022.03/node/Dockerfile -t cimg/android:2022.03.1-node  -t cimg/android:2022.03-node .
+docker build --file 2022.03/browsers/Dockerfile -t cimg/android:2022.03.1-browsers  -t cimg/android:2022.03-browsers .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker push cimg/android:2022.01.1
-docker push cimg/android:2022.01
-docker push cimg/android:2022.01.1-ndk
-docker push cimg/android:2022.01-ndk
-docker push cimg/android:2022.01.1-node
-docker push cimg/android:2022.01-node
-docker push cimg/android:2022.01.1-browsers
-docker push cimg/android:2022.01-browsers
+docker push cimg/android:2022.03.1
+docker push cimg/android:2022.03
+docker push cimg/android:2022.03.1-ndk
+docker push cimg/android:2022.03-ndk
+docker push cimg/android:2022.03.1-node
+docker push cimg/android:2022.03-node
+docker push cimg/android:2022.03.1-browsers
+docker push cimg/android:2022.03-browsers


### PR DESCRIPTION
Published the March 2022 Android Convenience Image. This will be closely followed by the Android machine release for March.

Closes #31 