### PR TITLE
Install default build-tools version for AGP 7.3.0

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -65,7 +65,7 @@ RUN SDK_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-lin
 
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "tools" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platform-tools" && \
-	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "build-tools;33.0.1"
+	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "build-tools;33.0.3"
 
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-33" && \
 	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-32" && \


### PR DESCRIPTION
I'm assuming this image is optimized for projects using AGP 7.3.0, but the current build-tools being installed (`30.0.0`) is not the default for that plugin version. This means that the [default build tools version](https://developer.android.com/studio/releases/gradle-plugin#compatibility-7-3-0) (`30.0.3`) gets installed during Android compilation tasks (`./gradle assembleDebug` for example).