### PR TITLE
chore: docker comment about default jdk version, 11 to 17

### DIFF
--- a/2023.03/Dockerfile
+++ b/2023.03/Dockerfile
@@ -10,7 +10,7 @@ FROM cimg/base:2023.03
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-# Java 11 is default
+# Java 17 is default
 RUN sudo apt-get update && sudo apt-get install -y \
 		ant \
 		openjdk-8-jdk \
@@ -26,7 +26,7 @@ ENV M2_HOME /usr/local/apache-maven
 ENV MAVEN_OPTS -Xmx2048m
 ENV PATH $M2_HOME/bin:$PATH
 # Set JAVA_HOME (and related) environment variable. This will be set to our
-# default Java version of 11 but the user would need to reset it when changing
+# default Java version of 17 but the user would need to reset it when changing
 # JAVA versions.
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ENV JDK_HOME=${JAVA_HOME}

--- a/2023.04/Dockerfile
+++ b/2023.04/Dockerfile
@@ -10,7 +10,7 @@ FROM cimg/base:2023.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-# Java 11 is default
+# Java 17 is default
 RUN sudo apt-get update && sudo apt-get install -y \
 		ant \
 		openjdk-8-jdk \
@@ -26,7 +26,7 @@ ENV M2_HOME /usr/local/apache-maven
 ENV MAVEN_OPTS -Xmx2048m
 ENV PATH $M2_HOME/bin:$PATH
 # Set JAVA_HOME (and related) environment variable. This will be set to our
-# default Java version of 11 but the user would need to reset it when changing
+# default Java version of 17 but the user would need to reset it when changing
 # JAVA versions.
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ENV JDK_HOME=${JAVA_HOME}


### PR DESCRIPTION
In 2023.03 and 2023.04, default JDK was changed to version 17. It appears that there was a missed update to the comments in the Dockerfile, so we have made the necessary changes to address this.