### PR TITLE
fixup: we only track 3 versions of the build-tools

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -68,8 +68,7 @@ RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "tools" && \
     echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platform-tools" && \
     echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "build-tools;35.0.0-rc4" && \
     echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "build-tools;34.0.0-rc3" && \
-    echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "build-tools;33.0.3" && \
-    echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "build-tools;32.1.0-rc1"
+    echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "build-tools;33.0.3"
 RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-29" && \
     echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-30" && \
     echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "platforms;android-31" && \


### PR DESCRIPTION
# Description
Remove the rogue fourth build-tools entry to ensure the `androidFeed.sh` can properly update the template on automated update flows.

# Reasons
Without this change, the automated update workflows will generate invalid `Dockerfile.template` changes.