### PR TITLE
Fix selected NDK versions

### DIFF
--- a/androidFeed.sh
+++ b/androidFeed.sh
@@ -65,15 +65,15 @@ CMAKE_VERS=$(sdkmanager --list | grep cmake | cut -d'|' -f1 | sort -Vr | tr -d '
 
 readarray -t CMAKE_ARRAY <<< "$CMAKE_VERS"
 
-NDK_VERS=$(sdkmanager --list | grep ndk | cut -d'|' -f1 | sort -Vr | tr -d '[:blank:]' | sed 's/ndk;//g' | awk -F. '!seen[$1"."]++' | head -2)
+NDK_VERS=$(sdkmanager --list | grep ndk | grep -v 'rc[[:digit:]]' | cut -d'|' -f1 | sort -Vr | tr -d '[:blank:]' | sed 's/ndk;//g' | awk -F. '!seen[$1"."]++' | head -2)
 
 readarray -t NDK_ARRAY <<< "$NDK_VERS"
 echo ${NDK_ARRAY[1]}
 
 sed -i '7c\RUN echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "'"${CMAKE_ARRAY[1]}"'" && \\' variants/ndk.Dockerfile.template
 sed -i '8c\	echo y | ${CMDLINE_TOOLS_ROOT}/sdkmanager "'"${CMAKE_ARRAY[0]}"'"' variants/ndk.Dockerfile.template
-sed -i '12c\ENV NDK_LTS_VERSION "'"${NDK_ARRAY[0]}"'"' variants/ndk.Dockerfile.template
-sed -i '20c\ENV NDK_STABLE_VERSION "'"${NDK_ARRAY[1]}"'"' variants/ndk.Dockerfile.template
+sed -i '12c\ENV NDK_LTS_VERSION "'"${NDK_ARRAY[1]}"'"' variants/ndk.Dockerfile.template
+sed -i '20c\ENV NDK_STABLE_VERSION "'"${NDK_ARRAY[0]}"'"' variants/ndk.Dockerfile.template
 
 
 shared/gen-dockerfiles.sh "$RELEASE"


### PR DESCRIPTION
# Description

- Filter out release candidates, as stable and LTS releases are expected
- invert NDK_ARRAY order, as sort order is reversed (major number of LTS versions is lower than that of stable version)

# Reasons

Current list of NDKs:
```
$ sdkmanager --list | grep ndk | cut -d'|' -f2 | sort -Vr
 29.0.13599879 rc2 
 29.0.13113456 rc1 
 28.1.13356709     
 28.0.13004108     
 28.0.12916984 rc3 
 28.0.12674087 rc2 
 28.0.12433566 rc1 
 27.2.12479018     
```
Before the fix, pre-releases are selected:
```
$ sdkmanager --list | grep ndk | cut -d'|' -f1 | sort -Vr | tr -d '[:blank:]' | sed 's/ndk;//g' | awk -F. '!seen[$1"."]++' | head -2
29.0.13599879
28.1.13356709
```
With the fix applied, selected versions match LTS and stable versions on https://developer.android.com/ndk/downloads
```
$ sdkmanager --list | grep ndk | grep -v 'rc[[:digit:]]' | cut -d'|' -f1 | sort -Vr | tr -d '[:blank:]' | sed 's/ndk;//g' | awk -F. '!seen[$1"."]++' | head -2
28.1.13356709
27.2.12479018
```

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
