### PR TITLE
Fix for build-tools versions to put into the Dockerfile.template.

### DIFF
--- a/androidFeed.sh
+++ b/androidFeed.sh
@@ -37,10 +37,13 @@ echo "Maven version: $MAVEN_VERSION"
 FASTLANE_VERSION=$(curl --silent "https://api.github.com/repos/fastlane/fastlane/releases/latest" | jq -r .tag_name)
 echo "Fastlane version: $FASTLANE_VERSION"
 
-NON_RC_BT=$(sdkmanager --list | grep "build-tools" | awk -F';' '{print $2}' | awk -F'|' '{print $1}' | tr -d '[:blank:]' | grep -v 'rc')
-LATEST_STABLE_BT=$(echo "$NON_RC_BT" | sort -Vr | head -1)
-BASE_RELEASES_BT=$(echo "$NON_RC_BT" | grep '\.0\.0$' | sort -Vr | head -3)
-BUILD_TOOLS_VERSIONS=$(printf '%s\n%s' "$LATEST_STABLE_BT" "$BASE_RELEASES_BT" | sort -Vr | uniq | head -n 4)
+# Unique stable Build Tools versions sorted in the descending order
+NON_RC_BT=$(sdkmanager --list | grep "build-tools" | awk -F';' '{print $2}' | awk -F'|' '{print $1}' | tr -d '[:blank:]' | grep -v 'rc' | sort -Vru )
+LATEST_STABLE_BT=$(echo "$NON_RC_BT" | head -1)
+# Skipping the latest stable, as it can result in a duplicate
+BASE_RELEASES_BT=$(echo "$NON_RC_BT" | tail -n +2 | grep '\.0$' | head -3)
+# 1 latest stable + 3 base releases = 4 unique versions
+BUILD_TOOLS_VERSIONS=$(printf '%s\n%s' "$LATEST_STABLE_BT" "$BASE_RELEASES_BT" )
 
 readarray -t BUILD_TOOLS_ARRAY <<< "$BUILD_TOOLS_VERSIONS"
 


### PR DESCRIPTION
# Description
Improving the logic for picking the Android Build Tools to install.

# Reasons
The #190 altered the logic how the Build Tools are selected, introducing a couple of issues causing all of the subsequent monthly releases to fail:
- #198 
- #200 
- #201 

The symptom of the issues is:
> Warning: Failed to find package 'build-tools;'

All the 'build-tools' require a version to be specified. Today the androidFeed.sh expects to discover [exactly 4 build tools versions](https://github.com/CircleCI-Public/cimg-android/blob/e71684386709b94a120aefe211da2fe553c30725/androidFeed.sh#L54-L57), but in fact it can discover less. Here is why:
- NON_RC_BT could have duplicates from the start, because `sdkmanager --list` outputs both 'known components', as well as 'already installed'.
- LATEST_STABLE_BT could be among BASE_RELEASES_BT versions.

As the result, BUILD_TOOLS_VERSIONS could have less than 4 values after `uniq`, causing `BUILD_TOOLS_ARRAY[3]` to be empty.

I changed the logic how these variables receive their values, ensuring the `BUILD_TOOLS_VERSIONS` has always exactly 4 unique values.

Also I allowed minor releases to be found, otherwise `36.1.0` would be missing.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
